### PR TITLE
Add interactive DC weekend itinerary

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,8 @@
 </head>
 <body>
   <main>
-    <h1>DC Trip Itinerary</h1>
-    <form id="itinerary-form">
-      <input type="text" id="item-input" placeholder="Add new item" required />
-      <button type="submit">Add</button>
-    </form>
-    <ul id="itinerary-list">
-      <li>Day 1: Visit the National Mall</li>
-      <li>Day 2: Explore Smithsonian Museums</li>
-      <li>Day 3: Tour the Capitol Building</li>
-    </ul>
+    <h1>DC Weekend Itinerary</h1>
+    <div id="itinerary"></div>
   </main>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,15 +1,61 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('itinerary-form');
-  const input = document.getElementById('item-input');
-  const list = document.getElementById('itinerary-list');
+  const itinerary = {
+    'Friday, October 3, 2025': [
+      '3:00 PM: Land at Reagan National (DCA)',
+      '3:30 PM: Check in at Courtyard by Marriott Foggy Bottom',
+      '4:30–7:00 PM: Walk the Lincoln, Vietnam Veterans, Korean War, and WWII Memorials',
+      '6:30 PM: Dinner at Founding Farmers DC',
+      '8:15 PM: White House North Lawn photos',
+      '9:00 PM: Stroll back toward hotel & wind down'
+    ],
+    'Saturday, October 4, 2025': [
+      '7:00–8:00 AM: Breakfast at hotel',
+      '9:00–11:00 AM: Smithsonian National Museum of American History',
+      '11:15 AM–1:00 PM: National Air & Space Museum',
+      '1:00 PM: Lunch at Mitsitam Café (American Indian Museum)',
+      '2:00–3:30 PM: U.S. Holocaust Memorial Museum',
+      '4:00–6:00 PM: White House West Wing tour',
+      '6:30 PM: Dinner at Old Ebbitt Grill',
+      'Evening: Optional stroll through Penn Quarter or Georgetown waterfront'
+    ],
+    'Sunday, October 5, 2025': [
+      '6:00 AM: Wake and quick breakfast',
+      '6:45 AM: Uber to DCA',
+      '8:00 AM: Depart for Omaha',
+      '10:30 AM (CDT): Arrive back in Omaha'
+    ]
+  };
 
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const text = input.value.trim();
-    if (!text) return;
-    const li = document.createElement('li');
-    li.textContent = text;
-    list.appendChild(li);
-    input.value = '';
+  const container = document.getElementById('itinerary');
+
+  Object.entries(itinerary).forEach(([day, events]) => {
+    const section = document.createElement('section');
+    section.className = 'day';
+
+    const heading = document.createElement('h2');
+    heading.textContent = day;
+    section.appendChild(heading);
+
+    const list = document.createElement('ul');
+
+    events.forEach((event) => {
+      const item = document.createElement('li');
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.addEventListener('change', () => {
+        item.classList.toggle('completed', checkbox.checked);
+      });
+      item.appendChild(checkbox);
+
+      const span = document.createElement('span');
+      span.textContent = event;
+      item.appendChild(span);
+
+      list.appendChild(item);
+    });
+
+    section.appendChild(list);
+    container.appendChild(section);
   });
 });
+

--- a/styles.css
+++ b/styles.css
@@ -14,30 +14,13 @@ main {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-form {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+.day {
+  margin-bottom: 2rem;
 }
 
-input[type="text"] {
-  flex: 1;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-
-button {
-  padding: 0.5rem 1rem;
-  background: #007acc;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-button:hover {
-  background: #005fa3;
+.day h2 {
+  margin-bottom: 0.5rem;
+  color: #007acc;
 }
 
 ul {
@@ -46,6 +29,23 @@ ul {
 }
 
 li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   padding: 0.5rem 0;
   border-bottom: 1px solid #eee;
 }
+
+li:last-child {
+  border-bottom: none;
+}
+
+.completed span {
+  text-decoration: line-through;
+  color: #888;
+}
+
+input[type='checkbox'] {
+  accent-color: #007acc;
+}
+


### PR DESCRIPTION
## Summary
- Replace placeholder itinerary with dynamic rendering of full DC weekend schedule
- Add JavaScript to generate day-by-day lists and allow checking off completed items
- Update styling for a clean layout and completed-task indicators

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b9d02375048322850f117711b8290d